### PR TITLE
add instructions on how to use make to develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,35 @@ clean:
 
 .PHONY: clean
 
+lambda-create:
+	aws lambda create-function \
+		--function-name planetbot \
+		--runtime python2.7 \
+		--handler handler.Handle \
+		--zip-file fileb://handler.zip \
+		--role arn:aws:iam::097545936362:role/service-role/lambda
+
+.PHONY: lambda-create
+
+lambda-upload:
+	aws lambda update-function-code \
+		--function-name planetbot \
+		--zip-file fileb://handler.zip
+
+.PHONY: lambda-upload
+
+lambda-invoke:
+	touch /tmp/output.txt; \
+	aws lambda invoke \
+		--function-name planetbot \
+		/tmp/output.txt; \
+	cat /tmp/output.txt
+
+.PHONY: lambda-invoke
+
+update:
+	make docker
+	make lambda-upload
+	make lambda-invoke
+
+.PHONY: update

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # planetbot
 
+## Getting Started
+
 Welcome! To get started on development:
 
 ### Slack - we use Slack for communication:
@@ -7,8 +9,11 @@ Welcome! To get started on development:
 + Join #planetbot
 
 ### AWS - we use Lex, Lambda etc.
-+ Ask Senthil (me@sent-hil.com) for AWS access
++ Ask Senthil (me@sent-hil.com) for AWS access and credentials
 + Once you’ve access, you can log into: https://097545936362.signin.aws.amazon.com/console
++ Install Brew from https://brew.sh (optional)
++ Install AWS CLI: `brew install awscli`
++ Configure AWS CLI with `aws configure` (you'll be given credentials with AWS access)
 
 ### Golang (optional)
 We use GoLang for writing lambda functions. If you’ve Go already installed you don’t need the following:
@@ -33,3 +38,12 @@ This'll build the zip file that you can upload to AWS Lambda
 ### Links
 + https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions/baaqmpd?tab=graph
 + https://console.aws.amazon.com/lex/home?region=us-east-1#bots:
+
+## Development
+
+There are helpers in Makefile to create, upload and invoke the lambda code.
+
++ To begin, let's create a lambda function: `make lambda-create`
++ Then run `make update` to upload the code and invoke it.
+
+From now after you make changes to the Go code, then can just run `make update` to upload the code and invoke it from command line.


### PR DESCRIPTION
 This PR makes it easy to develop on AWS Lambda by abstracting the build-upload-run code in a simple `make update` command.